### PR TITLE
Correct Option Spelling of StartLimitIntervalSec

### DIFF
--- a/syntaxes/systemd-unit-file.tmLanguage.json
+++ b/syntaxes/systemd-unit-file.tmLanguage.json
@@ -70,7 +70,7 @@
     "service-section-known-options": {
       "patterns": [{
         "name": "entity.name.tag",
-        "match": "\\b(Type|RemainAfterExit|GuessMainPID|PIDFile|BusName|BusPolicy|ExecStartPre|ExecStartPost|ExecStart|ExecReload|ExecStopPost|ExecStop|RestartSec|TimeoutStartSec|TimeoutStopSec|TimeoutSec|WatchdogSec|Restart|SuccessExitStatus|RestartPreventExitStatus|RestartForceExitStatus|PermissionsStartOnly|RootDirectoryStartOnly|NonBlocking|NotifyAccess|Sockets|StartLimitInterval|StartLimitBurst|StartLimitAction|FailureAction|RebootArgument|FileDescriptorStoreMax|KillMode|KillSignal|SendSIGHUP|SendSIGKILL|FinalKillSignal|WatchdogSignal)\\b"
+        "match": "\\b(Type|RemainAfterExit|GuessMainPID|PIDFile|BusName|BusPolicy|ExecStartPre|ExecStartPost|ExecStart|ExecReload|ExecStopPost|ExecStop|RestartSec|TimeoutStartSec|TimeoutStopSec|TimeoutSec|WatchdogSec|Restart|SuccessExitStatus|RestartPreventExitStatus|RestartForceExitStatus|PermissionsStartOnly|RootDirectoryStartOnly|NonBlocking|NotifyAccess|Sockets|StartLimitIntervalSec|StartLimitBurst|StartLimitAction|FailureAction|RebootArgument|FileDescriptorStoreMax|KillMode|KillSignal|SendSIGHUP|SendSIGKILL|FinalKillSignal|WatchdogSignal)\\b"
       }]
     },
     "socket-section-known-options": {


### PR DESCRIPTION
StartLimitInterval => StartLimitIntervalSec

[See docs](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=interval)