### PR TITLE
docs: Add Security section to README (fixes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ MIT License
 ## Repository
 
 https://github.com/bearmini/vscode-systemd-unit-file
+
+## Security
+
+Re. the Security Warning about _"The update for systemd-unit-file extension introduces executable code, which is not present in the currently installed version. Please review the extension and update it manually."_ which you'll see in Visual Studio Code's Extensions when upgrading previous versions to v1.0.8, please see issues [#17](https://github.com/bearmini/vscode-systemd-unit-file/issues/17) and [#15](https://github.com/bearmini/vscode-systemd-unit-file/issues/15).


### PR DESCRIPTION
Mention the new security warning that appears when upgrading to version v1.0.8 on the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Security section to the README describing a VS Code extension security warning encountered when upgrading to v1.0.8.
  * Included references to related issues (#17 and #15) for further details and tracking.
  * Clarified that there are no functional changes or public API modifications associated with this update.
  * Provides guidance and visibility for users who may see the warning during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->